### PR TITLE
Replace open all mines logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,7 +62,7 @@ function App() {
 
     let allocatedMines = 0;
 
-    const locationOfMines = [];
+    const newMineLocations = [];
     
     while (allocatedMines < mineCount) {
       let row = Math.floor(Math.random() * rowCount);
@@ -78,12 +78,12 @@ function App() {
       }
 
       if (!tile.hasMine ) {
-        locationOfMines.push({x: tile.x, y: tile.y})
+        newMineLocations.push({x: tile.x, y: tile.y})
         tile.hasMine = true;
         allocatedMines++;
       }
     }
-    return locationOfMines;
+    return newMineLocations;
   };
 
   const countAdjacentMines = (selectedTile, tiles, boardSize) => {
@@ -170,7 +170,6 @@ function App() {
       
       updatedBoard = revealUnflaggedMines(updatedBoard);
       updatedBoard = markIncorrectlyPlacedFlags(updatedBoard);
-      
       return [updatedBoard, tilesOpenedOnClick];
     } 
     currentTile.adjacentMinesCount = countAdjacentMines(
@@ -220,13 +219,13 @@ function App() {
     let currentBoard = [...board];
 
     if ( ! minesHaveBeenAssigned ){
-      const locationOfMines = assignMines(
+      const newMineLocations = assignMines(
         selectedTile,
         currentBoard,
         gameDifficultySettings.mineCount,
         gameDifficultySettings.boardSize
       );
-      setMineLocations(locationOfMines);
+      setMineLocations(newMineLocations);
       setMinesHaveBeenAssigned(true);
     }
 
@@ -291,21 +290,21 @@ function App() {
     }
     updatedBoard[rowIndex][colIndex] = updatedTile;
 
-    let locationOfFlags = [];
+    let updatedFlagLocations = [];
 
     if ( isFlagged ){
       flagCount  = flagCount - 1;
-      locationOfFlags = [...flagLocations, {x: selectedTile.x, y: selectedTile.y}];
+      updatedFlagLocations = [...flagLocations, {x: selectedTile.x, y: selectedTile.y}];
     }
     else {
       flagCount = flagCount + 1;
-      locationOfFlags = flagLocations.filter(
+      updatedFlagLocations = flagLocations.filter(
         (flagLocation) =>
           flagLocation.x !== selectedTile.x && flagLocation.y !== selectedTile.y
       );
     }
     setRemainingFlagsCount(flagCount);
-    setFlagLocations(locationOfFlags);
+    setFlagLocations(updatedFlagLocations);
     setBoard(updatedBoard);
   };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -170,8 +170,7 @@ function App() {
       
       updatedBoard = revealUnflaggedMines(updatedBoard);
       updatedBoard = markIncorrectlyPlacedFlags(updatedBoard);
-
-
+      
       return [updatedBoard, tilesOpenedOnClick];
     } 
     currentTile.adjacentMinesCount = countAdjacentMines(
@@ -296,14 +295,14 @@ function App() {
 
     if ( isFlagged ){
       flagCount  = flagCount - 1;
+      locationOfFlags = [...flagLocations, {x: selectedTile.x, y: selectedTile.y}];
+    }
+    else {
+      flagCount = flagCount + 1;
       locationOfFlags = flagLocations.filter(
         (flagLocation) =>
           flagLocation.x !== selectedTile.x && flagLocation.y !== selectedTile.y
       );
-    }
-    else {
-      flagCount = flagCount + 1;
-      locationOfFlags = [...flagLocations, {x: selectedTile.x, y: selectedTile.y}]
     }
     setRemainingFlagsCount(flagCount);
     setFlagLocations(locationOfFlags);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,7 +110,7 @@ function App() {
     return adjacentMinesCount;
   };
 
-  const markIncorrectlyPlacedFlags = (gameBoard, currentFlagLocations) => {
+  const getIncorrectlyFlaggedTiles = (gameBoard, currentFlagLocations) => {
     const updatedTiles = [];
 
     for (const flagLocation of currentFlagLocations) {
@@ -128,7 +128,7 @@ function App() {
     return updatedTiles;
   };
 
-  const revealUnflaggedMines = (gameBoard, currentMineLocations) => {
+  const getRevealedMineTiles = (gameBoard, currentMineLocations) => {
     const updatedTiles = [];
 
     for (const mineLocation of currentMineLocations) {
@@ -189,8 +189,8 @@ function App() {
 
       const updatedBoard = [...currentBoard];
       
-      const revealedMineTiles = revealUnflaggedMines(updatedBoard, mineLocations);
-      const incorrectlyFlaggedTiles = markIncorrectlyPlacedFlags(updatedBoard, flagLocations);
+      const revealedMineTiles = getRevealedMineTiles(updatedBoard, mineLocations);
+      const incorrectlyFlaggedTiles = getIncorrectlyFlaggedTiles(updatedBoard, flagLocations);
 
       const updatedTiles = [...revealedMineTiles,...incorrectlyFlaggedTiles ];
 


### PR DESCRIPTION
The aim of this refactor is to replace the openAlMines function, which contains multiple issues. When the function was first wrriten, the logic was a lot simpler and actually reflected the name - _any_ mines are opened, and flags are removed. I realised that other versions of the game that I had played have much more sophisticated behaviour:
- Only _unflagged_ mines are opened.
- _Incorrectly_ placed flags are highlighted with some sort of visual indicator - i.e. replaced with a cross icon in Google's version

The current version of the openAllMines function implements this much more sophisticated behaviour, but doesn't feel very clean any more:
- It's mixing the separate concerns of opening unflagged mines and validating the flag placements 
- The nested conditional logic makes it harder to read

As the function is traversing the board using a nested map, it also feels needlessly inefficient.

The refactored code replaces the single function with two new functions to seperate the concerns of opening unflagged mines and validation of flag placement. Whilst  mine placement is known after the first click, and does not change, meaning there is no need to traverse the entire board to open the mines, flag placement validation is more complex. I am sure improvements can be made, but the changes are a step in the right direction. 