### PR TITLE
fix: avoid re-render in remaining flags counter and game difficulty selector

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import {
 }
 from "./minesweeperUtils.js"
   
+import { useCallback } from "react";
 
 import "./App.css";
 
@@ -48,21 +49,21 @@ function App() {
     setupNewGame();
   }, [gameDifficultySettings]);
 
-  const onGameDifficultyLevelChanged = (event) => {
+  const onGameDifficultyLevelChanged = useCallback((event) => {
     const selectedLevel = event.target.value;
 
     const difficultyLevel = Object.values(GAME_DIFFICULTY_LEVEL_SETTINGS).find(
       (difficultySetting) => selectedLevel === difficultySetting.level
     );
 
-    if (! difficultyLevel) {
+    if (!difficultyLevel) {
       return;
     }
 
     resetBoardContainerScroll();
     setGameStatus(GameStatus.GAME_NOT_STARTED);
     setGameDifficultySettings(difficultyLevel)
-  };
+  }, []);
 
   const onCloseGameResultModal = () => {
     const gameResultModal = document.getElementById("gameResultModal");

--- a/src/components/GameDifficultySelector.jsx
+++ b/src/components/GameDifficultySelector.jsx
@@ -1,26 +1,25 @@
 import { GAME_DIFFICULTY_LEVEL_SETTINGS } from "../config/gameDifficultyLevelSettings";
+import { memo } from "react";
 
-function GameDifficultySelector({gameDifficultySettings, onChange}) {
-
-    return (
-        <div className='game-difficulty-select-wrapper'>
-        <label>Difficulty: </label>
-        <select 
-            value={gameDifficultySettings.level}
-            onChange={onChange}
-            name="game-difficulty-select" 
-            id="game-difficulty-select"
-            data-testid="difficulty-select"
-        > 
+function GameDifficultySelector({ gameDifficultySettings, onChange }) {
+  return (
+    <div className="game-difficulty-select-wrapper">
+      <label>Difficulty: </label>
+      <select
+        value={gameDifficultySettings.level}
+        onChange={onChange}
+        name="game-difficulty-select"
+        id="game-difficulty-select"
+        data-testid="difficulty-select"
+      >
         {Object.keys(GAME_DIFFICULTY_LEVEL_SETTINGS).map((setting, i) => (
-            <option 
-                key={i}
-                value={GAME_DIFFICULTY_LEVEL_SETTINGS[setting].level}
-            >{GAME_DIFFICULTY_LEVEL_SETTINGS[setting].label}</option>
+          <option key={i} value={GAME_DIFFICULTY_LEVEL_SETTINGS[setting].level}>
+            {GAME_DIFFICULTY_LEVEL_SETTINGS[setting].label}
+          </option>
         ))}
       </select>
     </div>
-    );
+  );
 }
 
-export default GameDifficultySelector;
+export default memo(GameDifficultySelector);

--- a/src/components/RemainingFlagsCounter.jsx
+++ b/src/components/RemainingFlagsCounter.jsx
@@ -1,19 +1,17 @@
-import { Flag } from "@phosphor-icons/react"
+import { Flag } from "@phosphor-icons/react";
 import { AccessibleIcon } from "@radix-ui/react-accessible-icon";
+import { memo } from "react";
 
 function RemainingFlagsCounter({ remainingFlagsCount }) {
-    return (
-
-        <div id="remainingFlagsCounter" data-testid="flags-remaining">
-
-            <AccessibleIcon label="flag icon">
-                <Flag size={25} color="#c01c28" weight="fill" />
-            </AccessibleIcon>
-            <span id="remainingFlagsLabel">Remaining Flags:</span>
-            <span id="remainingFlagsCount">{remainingFlagsCount}</span>
-
-        </div>
-    );
+  return (
+    <div id="remainingFlagsCounter" data-testid="flags-remaining">
+      <AccessibleIcon label="flag icon">
+        <Flag size={25} color="#c01c28" weight="fill" />
+      </AccessibleIcon>
+      <span id="remainingFlagsLabel">Remaining Flags:</span>
+      <span id="remainingFlagsCount">{remainingFlagsCount}</span>
+    </div>
+  );
 }
 
-export default RemainingFlagsCounter;
+export default memo(RemainingFlagsCounter);


### PR DESCRIPTION
fixes #48 

# Description

This PR points to avoid re-rendering the remaining flags counter and the game difficulty selector. This is done by converting the components in memoized components, indicating to React that those are pure components and not needs re-rendering at least the one of the props that it receives changes.

I wanted to fix it in general, avoiding Game Board and Cells re-rendering when one of the cells is clicked, but I found that they receive some callbacks functions, that internally uses the whole board to work, so I noticed those components needs to be re-rendering each time at least one of the cells are clicked. And fixing it would require a deeper refactor.

I am not sure if the logic is: "When a cell is clicked, all the board is updated with new probabilities and mines", or "At beggining of the game it's already decided what cell have bombs and we don't touch this until a new game is created", as the possibility of avoid re-rendering the whole board depends of that logic :), please let me know so I can see if I can do a next deeper refactor!.

# Screenshots

![rerenders](https://github.com/user-attachments/assets/504570b7-11c3-412d-8bea-95a3186f083f)
 