### PR TITLE
Fixing up vitest config

### DIFF
--- a/src/components/feature/GameBoard/Cell/Cell.test.tsx
+++ b/src/components/feature/GameBoard/Cell/Cell.test.tsx
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import Cell from './Cell';
+
+afterEach(cleanup);
 
 describe('Cell', () => {
   const defaultCell = {

--- a/src/components/feature/GameBoard/GameBoard.test.tsx
+++ b/src/components/feature/GameBoard/GameBoard.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
 import GameBoard from './GameBoard';
+
+afterEach(cleanup);
 
 describe('GameBoard component', () => {
   it('renders GameBoard and displays cells', () => {

--- a/src/components/feature/ResultModal/ResultModal.test.tsx
+++ b/src/components/feature/ResultModal/ResultModal.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import ResultModal from './ResultModal';
+
+afterEach(cleanup);
 
 describe('ResultModal', () => {
   it('does not render when initially closed', () => {

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,2 +1,0 @@
-import '@testing-library/jest-dom/vitest';
-

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,13 +27,11 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    globals: true,
 
     // Co-located tests + legacy /tests folder
     include: [
       'src/**/*.{test,spec}.{js,jsx,ts,tsx}',
       'tests/**/*.{test,spec}.{js,jsx,ts,tsx}',
     ],
-    setupFiles: ['./tests/setupTests.ts'],
   },
 });


### PR DESCRIPTION
## Description

This updates the Minesweeper Vitest configuration so tests no longer depend on a shared tests/setupTests.ts file or global Vitest APIs.

### Changes

- Removed globals: true from vite.config.ts.
- Removed the setupFiles reference to tests/setupTests.ts.
- Deleted tests/setupTests.ts.
- Updated React component tests to explicitly import Vitest APIs such as afterEach, describe, it, expect, and vi.
- Added explicit React Testing Library cleanup calls in component test files that render DOM.
- Kept @testing-library/jest-dom/vitest imported directly in the test that uses jest-dom matchers.

### Why

This makes each test file self-contained and avoids hidden dependencies on global test setup. It also makes the Vitest environment easier to reason about because test utilities are imported where they are used.

### Validation

```
./node_modules/.bin/vitest run passes.
./node_modules/.bin/tsc -b passes.
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

- [x] I have tested these changes locally
- [x] I have tested these changes in multiple browsers/environments if applicable

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if needed

## How to Test

1. Checkout branch
2. Run `npm run test`
3. Ensure all tests complete without issue

## Screenshots (if applicable)

**N/A**

## Additional Notes

**N/A**
